### PR TITLE
Fix Habo municipality coat of arms (was showing Håbo's)

### DIFF
--- a/facts/coatOfArms/coat_of_arms.py
+++ b/facts/coatOfArms/coat_of_arms.py
@@ -100,6 +100,16 @@ def get_coat_of_arms(territory_name):
     return coat_of_arms_url
 
 
+def _normalize_territory_name(name):
+    """Normalize territory name for comparison by removing common suffixes."""
+    return re.sub(
+        r"( kommun| stad|s kommun|s stad| municipality)$",
+        "",
+        name.strip(),
+        flags=re.IGNORECASE,
+    ).strip()
+
+
 def get_territory_wiki_id(territory_name):
     """Get territory wiki ID from Wikidata."""
     url = "https://www.wikidata.org/w/api.php"
@@ -121,25 +131,40 @@ def get_territory_wiki_id(territory_name):
         if not search_results:
             return []
 
-        # Prefer entries with "kommun" or "municipality" in the label (municipality entries)
-        # as they're more likely to have coat of arms (P94)
+        normalized_search = _normalize_territory_name(territory_name)
+
+        # Prefer exact municipality matches first (e.g. Habo vs Håbo), then other
+        # municipality entries, then exact non-municipality matches, then the rest.
+        exact_kommun_entries = []
         kommun_entries = []
+        exact_other_entries = []
         other_entries = []
 
         for territory in search_results:
             territory_id = territory.get("id")
-            label = territory.get("label", "").lower()
-            description = territory.get("description", "").lower()
+            label = territory.get("label", "")
+            normalized_label = _normalize_territory_name(label)
+            is_exact_match = normalized_label == normalized_search
 
             # Check if this looks like a municipality entry
-            if ("kommun" in label or "municipality" in label or
-                "kommun" in description or "municipality" in description):
-                kommun_entries.append(territory_id)
+            if "kommun" in label.lower() or "municipality" in label.lower():
+                if is_exact_match:
+                    exact_kommun_entries.append(territory_id)
+                else:
+                    kommun_entries.append(territory_id)
+            elif is_exact_match:
+                exact_other_entries.append(territory_id)
             else:
                 other_entries.append(territory_id)
 
-        # Return municipality entries first, then others
-        wiki_ids = kommun_entries + other_entries or [search_results[0].get("id")]
+        wiki_ids = (
+            exact_kommun_entries
+            + kommun_entries
+            + exact_other_entries
+            + other_entries
+        )
+        if not wiki_ids:
+            wiki_ids = [search_results[0].get("id")]
 
         return wiki_ids
 

--- a/facts/municipalities_coat_of_arms.csv
+++ b/facts/municipalities_coat_of_arms.csv
@@ -58,7 +58,7 @@ Mjölby,0586,Östergötlands län,https://upload.wikimedia.org/wikipedia/commons
 Aneby,0604,Jönköpings län,https://upload.wikimedia.org/wikipedia/commons/4/45/Aneby_vapen.svg
 Gnosjö,0617,Jönköpings län,https://upload.wikimedia.org/wikipedia/commons/5/50/Gnosj%C3%B6_vapen.svg
 Mullsjö,0642,Jönköpings län,https://upload.wikimedia.org/wikipedia/commons/7/76/Mullsj%C3%B6_vapen.svg
-Habo,0643,Jönköpings län,https://upload.wikimedia.org/wikipedia/commons/d/d1/H%C3%A5bo_vapen.svg
+Habo,0643,Jönköpings län,https://upload.wikimedia.org/wikipedia/commons/1/17/Habo_vapen.svg
 Gislaved,0662,Jönköpings län,https://upload.wikimedia.org/wikipedia/commons/e/eb/Gislaved_vapen.svg
 Vaggeryd,0665,Jönköpings län,https://upload.wikimedia.org/wikipedia/commons/f/f9/Vaggeryd_vapen.svg
 Jönköping,0680,Jönköpings län,https://upload.wikimedia.org/wikipedia/commons/3/3c/J%C3%B6nk%C3%B6ping_vapen.svg

--- a/output/municipality-data.json
+++ b/output/municipality-data.json
@@ -3836,7 +3836,7 @@
   },
   {
     "name": "Habo",
-    "logoUrl": "https://upload.wikimedia.org/wikipedia/commons/d/d1/H%C3%A5bo_vapen.svg",
+    "logoUrl": "https://upload.wikimedia.org/wikipedia/commons/1/17/Habo_vapen.svg",
     "region": "Jönköpings län",
     "emissions": {
       "1990": 69722.651,

--- a/tests/test_coat_of_arms.py
+++ b/tests/test_coat_of_arms.py
@@ -22,6 +22,29 @@ class TestGetterritoryWikiID(unittest.TestCase):
         result = get_territory_wiki_id("NonexistentTown")
         self.assertEqual(result, [])
 
+    @patch("facts.coatOfArms.coat_of_arms.requests.get")
+    def test_prefers_exact_municipality_match(self, mock_get):
+        """Test that similarly named municipalities are disambiguated exactly."""
+        mock_get.return_value.json.return_value = {
+            "search": [
+                {
+                    "id": "Q503198",
+                    "label": "Habo kommun",
+                    "description": "kommun i Jönköpings län",
+                },
+                {
+                    "id": "Q511253",
+                    "label": "Håbo kommun",
+                    "description": "kommun i Uppsala län",
+                },
+            ]
+        }
+        result = get_territory_wiki_id("Habo")
+        self.assertEqual(result[0], "Q503198")
+
+        result = get_territory_wiki_id("Håbo")
+        self.assertEqual(result[0], "Q511253")
+
 
 class TestGetCoatOfArms(unittest.TestCase):
     """Test cases for retrieving coat of arms images from Wikidata."""


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Habo (Jönköpings län) and Håbo (Uppsala län) are different municipalities with distinct coats of arms, but Habo was incorrectly using Håbo's image on the site.

## Changes

- Corrected Habo's coat of arms URL in `facts/municipalities_coat_of_arms.csv` to `Habo_vapen.svg`
- Updated `output/municipality-data.json` so Habo's `logoUrl` points to the correct image
- Improved Wikidata lookup in `get_territory_wiki_id()` to prefer exact municipality name matches, preventing Habo/Håbo confusion when re-running `update_coat_of_arms.py`
- Added a unit test for Habo/Håbo disambiguation

## Verification

- `get_coat_of_arms("Habo")` now returns the fence/gärdesgård coat of arms
- `get_coat_of_arms("Håbo")` still returns the lamb (Agnus Dei) coat of arms
- All coat of arms unit tests pass
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d50859b8-e6cf-4e4a-af71-66fbd59d6c5a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d50859b8-e6cf-4e4a-af71-66fbd59d6c5a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

